### PR TITLE
Add Mission Control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem "cssbundling-rails", "~> 1.3"
 
 gem "propshaft"
 
-gem "solid_queue", "~> 0.1.2"
+gem "solid_queue", "~> 0.2.1"
 
 gem "activejob-status", "~> 1.0"
 
@@ -129,5 +129,3 @@ gem "doorkeeper-device_authorization_grant", "~> 1.0"
 gem "mission_control-jobs", "~> 0.1.1"
 
 gem "foreman", "~> 0.87.2"
-
-gem "mission_control-jobs", "~> 0.1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -129,3 +129,5 @@ gem "doorkeeper-device_authorization_grant", "~> 1.0"
 gem "mission_control-jobs", "~> 0.1.1"
 
 gem "foreman", "~> 0.87.2"
+
+gem "mission_control-jobs", "~> 0.1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -125,3 +125,5 @@ gem "doorkeeper-openid_connect", "~> 1.8"
 gem "rack-cors", "~> 2.0"
 
 gem "doorkeeper-device_authorization_grant", "~> 1.0"
+
+gem "mission_control-jobs", "~> 0.1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -127,3 +127,5 @@ gem "rack-cors", "~> 2.0"
 gem "doorkeeper-device_authorization_grant", "~> 1.0"
 
 gem "mission_control-jobs", "~> 0.1.1"
+
+gem "foreman", "~> 0.87.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
       syntax_tree (~> 6.0)
     erubi (1.12.0)
     ffi (1.16.3)
+    foreman (0.87.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     httparty (0.21.0)
@@ -464,6 +465,7 @@ DEPENDENCIES
   doorkeeper-openid_connect (~> 1.8)
   dotenv-rails
   erb-formatter
+  foreman (~> 0.87.2)
   importmap-rails (~> 1.2)
   jbuilder
   mission_control-jobs (~> 0.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,11 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.21.2)
+    mission_control-jobs (0.1.1)
+      importmap-rails
+      rails (~> 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.7.2)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
@@ -461,6 +466,7 @@ DEPENDENCIES
   erb-formatter
   importmap-rails (~> 1.2)
   jbuilder
+  mission_control-jobs (~> 0.1.1)
   pg
   postmark-rails
   propshaft

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,14 +97,14 @@ GEM
     bigdecimal (3.1.6)
     bindata (2.4.15)
     bindex (0.8.1)
-    bootsnap (1.17.1)
+    bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
-    capybara (3.39.2)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -116,9 +116,10 @@ GEM
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
     crass (1.0.6)
-    cssbundling-rails (1.3.3)
+    cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
-    dalli (3.2.6)
+    dalli (3.2.7)
+      base64
     date (3.3.4)
     debug (1.9.1)
       irb (~> 1.10)
@@ -206,6 +207,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
+    nokogiri (1.16.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
@@ -214,7 +217,7 @@ GEM
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     parallel (1.24.0)
-    parser (3.3.0.4)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -236,7 +239,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (3.0.8)
+    rack (3.0.9)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-session (2.0.0)
@@ -352,23 +355,24 @@ GEM
       yard (~> 0.9, >= 0.9.24)
     solid_cache (0.2.0)
       rails (>= 7)
-    solid_queue (0.1.2)
-      rails (>= 7.0.3.1)
-    sorbet (0.5.11213)
-      sorbet-static (= 0.5.11213)
-    sorbet-runtime (0.5.11213)
-    sorbet-static (0.5.11213-universal-darwin)
-    sorbet-static (0.5.11213-x86_64-linux)
-    sorbet-static-and-runtime (0.5.11213)
-      sorbet (= 0.5.11213)
-      sorbet-runtime (= 0.5.11213)
+    solid_queue (0.2.1)
+      rails (~> 7.1)
+    sorbet (0.5.11222)
+      sorbet-static (= 0.5.11222)
+    sorbet-runtime (0.5.11222)
+    sorbet-static (0.5.11222-universal-darwin)
+    sorbet-static (0.5.11222-x86_64-linux)
+    sorbet-static-and-runtime (0.5.11222)
+      sorbet (= 0.5.11222)
+      sorbet-runtime (= 0.5.11222)
     spoom (1.2.4)
       erubi (>= 1.10.0)
       sorbet-static-and-runtime (>= 0.5.10187)
       syntax_tree (>= 6.1.1)
       thor (>= 0.19.2)
-    sqlite3 (1.7.0-x86_64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.2-arm64-darwin)
+    sqlite3 (1.7.2-x86_64-darwin)
+    sqlite3 (1.7.2-x86_64-linux)
     standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -390,11 +394,13 @@ GEM
     syntax_suggest (2.0.0)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
+    tailwindcss-rails (2.3.0-arm64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.3.0-x86_64-darwin)
       railties (>= 6.0.0)
     tailwindcss-rails (2.3.0-x86_64-linux)
       railties (>= 6.0.0)
-    tapioca (0.11.17)
+    tapioca (0.12.0)
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
@@ -449,7 +455,9 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  x86_64-darwin-21
+  arm64-darwin
+  universal-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES
@@ -485,7 +493,7 @@ DEPENDENCIES
   sentry-rails (~> 5.13)
   solargraph
   solid_cache (~> 0.2.0)
-  solid_queue (~> 0.1.2)
+  solid_queue (~> 0.2.1)
   sorbet-runtime
   sqlite3 (~> 1.4)
   standard (~> 1.33)
@@ -504,4 +512,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.2
+   2.5.3

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -6,6 +6,7 @@
         <li><a href="/admin/domains">- View Domains</a></li>
          <li><a href="/admin/domains/review" data-turbo="false">- Review Domain Requests</a></li>
          <li><a href="/admin/developers/review" data-turbo="false">- Review Developer App Requests</a></li>
+         <li><a href="/admin/jobs">- Mission Control (Active Job)</a></li>
     </ul>
 </main>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,7 @@ module AdminOblOng
     config.assets.paths << Rails.root.join("app/javascript")
 
     config.slack_notify = false
+
+    config.mission_control.jobs.base_controller_class = "AdminController" 
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,6 @@ module AdminOblOng
 
     config.slack_notify = false
 
-    config.mission_control.jobs.base_controller_class = "AdminController" 
+    config.mission_control.jobs.base_controller_class = "AdminController"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module AdminOblOng
 
     config.action_mailer.delivery_method = :postmark
 
-    config.sentry = false
+    config.sentry = true
 
     config.action_mailer.postmark_settings = {
       api_token: Rails.application.credentials.postmark_api_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,9 @@ Rails.application.routes.draw do
       post "/review", to: "admin#developers_review_decision"
       get "/review", to: "admin#developers_review"
     end
-  end
+
+    mount MissionControl::Jobs::Engine, at: "/jobs"
+  end 
 
   get "users/register"
   post "users/create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
     end
 
     mount MissionControl::Jobs::Engine, at: "/jobs"
-  end 
+  end
 
   get "users/register"
   post "users/create"


### PR DESCRIPTION
This PR adds the Mission Control dashboard for Active Job, which is available at `/admin/jobs` for admins only.