### PR TITLE
Add multiplayer cursors and cursor chat

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 /* @layer components {
   .testing {
     @apply bg-red-200;
@@ -276,7 +275,7 @@ button, input[type=submit] {
 input[type=text], input[type=email], input[type=number], .input2, x-selectmenu::part(button) {
 	background-color: #262626 !important;
 	border: 1.5px solid var(--cultured)!important;
-	border-radius: 5px !important;
+	border-radius: 5px;
 	min-width: 350px;
 	color: white;
 }

--- a/app/channels/cursor_chat_channel.rb
+++ b/app/channels/cursor_chat_channel.rb
@@ -1,0 +1,13 @@
+class CursorChatChannel < ApplicationCable::Channel
+  include Y::Actioncable::Sync
+
+  def subscribed
+    # initiate sync & subscribe to updates, with optional persistence mechanism
+    sync_for(session)
+  end
+
+  def receive(message)
+    # broadcast update to all connected clients on all servers
+    sync_to(session, message)
+  end
+end

--- a/app/channels/cursor_chat_channel.rb
+++ b/app/channels/cursor_chat_channel.rb
@@ -1,13 +1,9 @@
 class CursorChatChannel < ApplicationCable::Channel
-  include Y::Actioncable::Sync
-
   def subscribed
-    # initiate sync & subscribe to updates, with optional persistence mechanism
-    sync_for(session)
+    stream_from params[:id]
   end
 
-  def receive(message)
-    # broadcast update to all connected clients on all servers
-    sync_to(session, message)
+  def receive(data)
+    ActionCable.server.broadcast(params[:id], data)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@ import "controllers"
 import "@hotwired/turbo-rails"
 import "selectlist"
 import("selectlist")
+

--- a/app/javascript/controllers/cursorchat_controller.js
+++ b/app/javascript/controllers/cursorchat_controller.js
@@ -1,0 +1,8 @@
+import { initCursorChat } from "cursor-chat"
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    initCursorChat()
+  }
+}

--- a/app/views/layouts/domain.html.erb
+++ b/app/views/layouts/domain.html.erb
@@ -1,5 +1,7 @@
+<%= stylesheet_link_tag "https://unpkg.com/cursor-chat/dist/style.css" %>
+
 <%# https://icons.hackclub.com/ %>
-<div class="flex flex-col lg:flex-row gap-12">
+<div class="flex flex-col lg:flex-row gap-12" data-controller="cursorchat">
     <div class="flex flex-row flex-wrap lg:flex-col gap-6 side-menu">
         <%# link to the dns action %>
         <%= link_to records_path(@domain) do %>
@@ -35,4 +37,8 @@
             <%= yield_nested %>
         </div>
     </div>
+</div>
+
+<div id="cursor-chat-layer">
+  <input type="text" id="cursor-chat-box">
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin "@github/webauthn-json/browser-ponyfill", to: "https://ga.jspm.io/npm:@githu
 pin "url-safe-base64", to: "https://ga.jspm.io/npm:url-safe-base64@1.3.0/src/index.js"
 pin_all_from "app/javascript"
 pin "selectlist", to: "https://esm.sh/selectlist-polyfill@0.3.0", preload: true
+pin "cursor-chat", to: "https://esm.sh/gh/obl-ong/cursor-chat-actioncable@9befe0089b/dist/cursor-chat.es.js"


### PR DESCRIPTION
This PR adds multiplayer cursors and cursor chat support through the use of Y.js, action cable, and https://github.com/obl-ong/cursor-chat-actioncable (forked from jackyzha0/cursor-chat)

This only adds multiplayer cursors to anything using the domain layout, that way it's scoped to a domain, and doesn't appear on every page. This also doesn't add synced text input, so the experience isn't seamless.