### PR TITLE
Add ActiveRecord::Encryption to models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,3 +129,5 @@ gem "doorkeeper-device_authorization_grant", "~> 1.0"
 gem "mission_control-jobs", "~> 0.1.1"
 
 gem "foreman", "~> 0.87.2"
+
+gem "mass_encryption", "~> 0.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    mass_encryption (0.1.1)
+      rails (>= 7.0.0)
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.21.2)
@@ -476,6 +478,7 @@ DEPENDENCIES
   foreman (~> 0.87.2)
   importmap-rails (~> 1.2)
   jbuilder
+  mass_encryption (~> 0.1.1)
   mission_control-jobs (~> 0.1.1)
   pg
   postmark-rails

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -20,6 +20,9 @@ class Domain < ApplicationRecord
     Domain::UpdateProvisionalCountJob.perform_later
   }
 
+  encrypts :host, deterministic: true
+  encrypts :plan
+
   def to_param
     host
   end

--- a/app/models/user/credential.rb
+++ b/app/models/user/credential.rb
@@ -1,2 +1,4 @@
 class User::Credential < ApplicationRecord
+  encrypts :webauthn_id, deterministic: true
+  encrypts :public_key, :sign_count, :name
 end


### PR DESCRIPTION
This pull requests adds ActiveRecord::Encryption to models to enable the encrypting of member data like names/emails/public key credentials/etc.

## Steps to migrate your data

1. Add `config.active_record.encryption.support_unencrypted_data = true` to your config/application.rb temporarily to allow for accessing cleartext data.
2. Add `config.active_job.queue_adapter = :solid_queue` to `app/environments/development.rb` & allow for solid queue in `config/puma.rb` to start solid queue in development
3. Start the rails server
4. Run `bin/rake mass_encryption:encrypt_all_in_parallel_jobs EXCEPT="ActionText::EncryptedRichText" --trace` to create jobs that will encrypt all the data
5. Run `SolidQueue::Job.all.first.dispatch` to start the job
6. Check Mission Control to check on it
7. You're done (hopefully)


If someone could write a rake task that would be greatly appreciated!

Closes #90