### PR TITLE
Add console auditing with console1984 & audits1984

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,5 +132,5 @@ gem "foreman", "~> 0.87.2"
 
 gem "mass_encryption", "~> 0.1.1"
 
-gem 'console1984'
-gem 'audits1984'
+gem "console1984"
+gem "audits1984"

--- a/Gemfile
+++ b/Gemfile
@@ -131,3 +131,6 @@ gem "mission_control-jobs", "~> 0.1.1"
 gem "foreman", "~> 0.87.2"
 
 gem "mass_encryption", "~> 0.1.1"
+
+gem 'console1984'
+gem 'audits1984'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,11 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     android_key_attestation (0.3.0)
     ast (2.4.2)
+    audits1984 (0.1.5)
+      console1984
+      rinku
+      rouge
+      turbo-rails
     awrence (1.2.1)
     backport (1.2.0)
     base64 (0.2.0)
@@ -112,6 +117,9 @@ GEM
     cbor (0.5.9.8)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    console1984 (0.1.31)
+      parser
+      rainbow
     cose (1.3.0)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
@@ -302,7 +310,9 @@ GEM
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.6)
+    rinku (2.0.6)
     rotp (6.3.0)
+    rouge (4.2.0)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -464,8 +474,10 @@ PLATFORMS
 
 DEPENDENCIES
   activejob-status (~> 1.0)
+  audits1984
   bootsnap
   capybara
+  console1984
   cssbundling-rails (~> 1.3)
   dalli (~> 3.2)
   debug

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -47,6 +47,10 @@ class AdminController < ApplicationController
     end
   end
 
+  def find_current_auditor
+    current_user if current_user.admin?
+  end
+
   private
 
   def require_admin

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -7,6 +7,7 @@
          <li><a href="/admin/domains/review" data-turbo="false">- Review Domain Requests</a></li>
          <li><a href="/admin/developers/review" data-turbo="false">- Review Developer App Requests</a></li>
          <li><a href="/admin/jobs">- Mission Control (Active Job)</a></li>
+         <li><a href="/admin/console">- audits1984 (Console Audits)</a></li>
     </ul>
 </main>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,6 @@ module AdminOblOng
     config.mission_control.jobs.base_controller_class = "AdminController"
     config.audits1984.base_controller_class = "AdminController"
     config.audits1984.auditor_class = "::User::User"
+    config.console1984.protected_urls = [ "https://api.dnsimple.com/v2/" ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,6 @@ module AdminOblOng
     config.mission_control.jobs.base_controller_class = "AdminController"
     config.audits1984.base_controller_class = "AdminController"
     config.audits1984.auditor_class = "::User::User"
-    config.console1984.protected_urls = [ "https://api.dnsimple.com/v2/" ]
+    config.console1984.protected_urls = ["https://api.dnsimple.com/v2/"]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,7 @@ module AdminOblOng
     config.slack_notify = false
 
     config.mission_control.jobs.base_controller_class = "AdminController"
+    config.audits1984.base_controller_class = "AdminController"
+    config.audits1984.auditor_class = "::User::User"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-Rails.application.routes.draw do
+Rails.application.routes.draw do  
   use_doorkeeper_openid_connect
   use_doorkeeper do
     skip_controllers :applications, :authorized_applications
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     end
 
     mount MissionControl::Jobs::Engine, at: "/jobs"
+    mount Audits1984::Engine => "/console"
   end
 
   get "users/register"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-Rails.application.routes.draw do  
+Rails.application.routes.draw do
   use_doorkeeper_openid_connect
   use_doorkeeper do
     skip_controllers :applications, :authorized_applications

--- a/db/migrate/20240220172414_create_console1984_tables.console1984.rb
+++ b/db/migrate/20240220172414_create_console1984_tables.console1984.rb
@@ -1,0 +1,36 @@
+# This migration comes from console1984 (originally 20210517203931)
+class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :console1984_sessions do |t|
+      t.text :reason
+      t.references :user, null: false, index: false
+      t.timestamps
+
+      t.index :created_at
+      t.index [ :user_id, :created_at ]
+    end
+
+    create_table :console1984_users do |t|
+      t.string :username, null: false
+      t.timestamps
+
+      t.index [:username]
+    end
+
+    create_table :console1984_commands do |t|
+      t.text :statements
+      t.references :sensitive_access
+      t.references :session, null: false, index: false
+      t.timestamps
+
+      t.index [ :session_id, :created_at, :sensitive_access_id ], name: "on_session_and_sensitive_chronologically"
+    end
+
+    create_table :console1984_sensitive_accesses do |t|
+      t.text :justification
+      t.references :session, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240220172414_create_console1984_tables.console1984.rb
+++ b/db/migrate/20240220172414_create_console1984_tables.console1984.rb
@@ -7,7 +7,7 @@ class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.index :created_at
-      t.index [ :user_id, :created_at ]
+      t.index [:user_id, :created_at]
     end
 
     create_table :console1984_users do |t|
@@ -23,7 +23,7 @@ class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
       t.references :session, null: false, index: false
       t.timestamps
 
-      t.index [ :session_id, :created_at, :sensitive_access_id ], name: "on_session_and_sensitive_chronologically"
+      t.index [:session_id, :created_at, :sensitive_access_id], name: "on_session_and_sensitive_chronologically"
     end
 
     create_table :console1984_sensitive_accesses do |t|

--- a/db/migrate/20240220173759_create_auditing_tables.audits1984.rb
+++ b/db/migrate/20240220173759_create_auditing_tables.audits1984.rb
@@ -1,0 +1,13 @@
+# This migration comes from audits1984 (originally 20210810092639)
+class CreateAuditingTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :audits1984_audits do |t|
+      t.integer :status, default: 0, null: false
+      t.text :notes
+      t.references :session, null: false
+      t.references :auditor, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_223915) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_173759) do
+  create_table "audits1984_audits", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.text "notes"
+    t.integer "session_id", null: false
+    t.integer "auditor_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["auditor_id"], name: "index_audits1984_audits_on_auditor_id"
+    t.index ["session_id"], name: "index_audits1984_audits_on_session_id"
+  end
+
+  create_table "console1984_commands", force: :cascade do |t|
+    t.text "statements"
+    t.integer "sensitive_access_id"
+    t.integer "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sensitive_access_id"], name: "index_console1984_commands_on_sensitive_access_id"
+    t.index ["session_id", "created_at", "sensitive_access_id"], name: "on_session_and_sensitive_chronologically"
+  end
+
+  create_table "console1984_sensitive_accesses", force: :cascade do |t|
+    t.text "justification"
+    t.integer "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_console1984_sensitive_accesses_on_session_id"
+  end
+
+  create_table "console1984_sessions", force: :cascade do |t|
+    t.text "reason"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_console1984_sessions_on_created_at"
+    t.index ["user_id", "created_at"], name: "index_console1984_sessions_on_user_id_and_created_at"
+  end
+
+  create_table "console1984_users", force: :cascade do |t|
+    t.string "username", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["username"], name: "index_console1984_users_on_username"
+  end
+
   create_table "domains", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
This PR adds console auditing for sensitive data on top of encryption with `console1984` and `audits1984`. Auditing is available for admins at `/admin/console`

Console sessions accessing member data must now be justified & audited through this system.