### PR TITLE
Fix duplicated `application` layout

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,6 @@
 class AdminController < ApplicationController
-  nested_layouts "layouts/application"
+  layout "application"
+  nested_layouts "layouts/admin"
 
   before_action :require_admin
 

--- a/app/controllers/developers/applications_controller.rb
+++ b/app/controllers/developers/applications_controller.rb
@@ -1,5 +1,5 @@
 class Developers::ApplicationsController < ApplicationController
-  nested_layouts "layouts/admin", "layouts/application"
+  nested_layouts "layouts/admin"
 
   before_action do
     @developers = true

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -9,8 +9,8 @@ class DomainsController < ApplicationController
   skip_before_action :require_admin, except: [:create, :transfer]
 
   helper DnsimpleHelper
-  nested_layouts "layouts/admin", "layouts/domain", "layouts/application", except: [:index, :request_domain, :show]
-  nested_layouts "layouts/admin", "layouts/application", only: [:index, :request_domain]
+  nested_layouts "layouts/admin", "layouts/domain", except: [:index, :request_domain, :show]
+  nested_layouts "layouts/admin", only: [:index, :request_domain]
 
   def index
     @domains = Domain.where(user_users_id: current_user.id)


### PR DESCRIPTION
### The Problem

View the source for the homepage. There's an `<html>` _inside_ an `<html>`!!!

<img width="1111" alt="Screenshot 2024-02-29 at 7 34 52 PM" src="https://github.com/obl-ong/admin/assets/34525547/6c25e775-97c8-41df-aa98-b01aa378c052">

`rails_nestable_layouts` automatically uses the `application` layout as the root, so specifying it in `nested_layouts` causes it to be rendered twice.