### PR TITLE
Fix styling on OAuth scope selector

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
     policy.script_src :self, "https://rebound.postmarkapp.com"
     policy.style_src :self, "https://unpkg.com/cursor-chat/dist/style.css"
     policy.style_src_attr :self, "'unsafe-inline'"
+    policy.style_src_elem :self, "'unsafe-inline'"
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end


### PR DESCRIPTION
The `selectlist` JS component relies on `<style>` elements for styling, but the current CSP (only enforced in production) disallows `<style>` elements!

Fixes #135.